### PR TITLE
Update Podfile.lock with lib new version.

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,7 +12,8 @@ PODS:
   - OCMockito (1.3.1):
     - OCHamcrest (~> 4.0)
   - Specta (0.2.1)
-  - WLXBluetoothDevice (0.1.0)
+  - WLXBluetoothDevice (0.1.0-alpha1):
+    - CocoaLumberjack (~> 2.0.0-beta)
 
 DEPENDENCIES:
   - CocoaLumberjack (~> 2.0.0-beta)
@@ -31,6 +32,6 @@ SPEC CHECKSUMS:
   OCHamcrest: b464725bbb48d0f1cd9c6f4ec3cb35fe0c4f2b94
   OCMockito: 57b8c4bb54ff3a4a14eb2174f9e57faf9f56efb6
   Specta: 9141310f46b1f68b676650ff2854e1ed0b74163a
-  WLXBluetoothDevice: 1467ef460c69b09de503555071de98dbfda0ef7b
+  WLXBluetoothDevice: 6436b3f16f7e2e1102b3c7d027afadf215f81e32
 
 COCOAPODS: 0.34.4


### PR DESCRIPTION
`Podfile.lock` was trying to fetch the pod spec version `0.1.0` using a path but the pod spec version is `0.1.0-alpha1` and it fails. 
Running this command fixes the issue:

``` bash
pod update WLXBluetoothDevice
```
