### PR TITLE
Bug on Reconnect

### DIFF
--- a/Pod/Classes/WLXBluetoothConnectionManager.m
+++ b/Pod/Classes/WLXBluetoothConnectionManager.m
@@ -164,8 +164,7 @@ DYNAMIC_LOGGER_METHODS
     }
     [self.reconnectionStrategy reset];
     _connected = YES;
-    _connecting = NO;
-    _reconnecting = NO;
+
     // We don't want to create a service manager every time a connection is made
     // because all the cached data will be lost if we do so. Using the same instance every time
     // is not a problem because an instance of connection manager always handles the same
@@ -185,6 +184,9 @@ DYNAMIC_LOGGER_METHODS
     } else if (!self.reconnecting) {
         [self.delegate connectionManagerDidConnect:self];
     }
+
+    _connecting = NO;
+    _reconnecting = NO;
 }
 
 #pragma mark - Private methods


### PR DESCRIPTION
Fixing a bug where -connectionManagerDidReconnect: wasn't getting called because _reconnecting was set to NO before calling the appropriate delegate method.